### PR TITLE
Fix mixed content warning on CC image

### DIFF
--- a/templates/landing.html
+++ b/templates/landing.html
@@ -239,7 +239,7 @@
 							<p>About EN | Other Locations </p>
 							<p><span class="license"><a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/">
 								<img alt="Creative Commons License" style="border-width:0"
-								src="http://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /> </a></span> 
+								src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /> </a></span> 
 								Fork the code on <a href="http://github.com/jessykate/modernomad">Github</a>
 							</p>
 						</div>


### PR DESCRIPTION
This is the only non-SSL image I could see in my Network tab in Chrome dev tools, so it should resolve the mixed content warning.

The `base.html` template links to a self-hosted image at [https://sf.embassynetwork.com/media/img/cc-by-nc-sa-80x15.png](https://sf.embassynetwork.com/media/img/cc-by-nc-sa-80x15.png), which you could alternatively replace the remotely linked to image with.