### PR TITLE
Add basic Docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,9 @@ ENV LIBRARY_PATH /lib:/usr/lib
 
 RUN pip install -r requirements.txt && \
     pip install --index-url https://code.stripe.com --upgrade stripe && \
-    mkdir logs
+    npm install -g less && \
+    cd client && npm install && \
+    node_modules/.bin/webpack --config webpack.prod.config.js
 
 EXPOSE 80
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM alpine
+RUN apk upgrade --update && \
+    apk add build-base py-pip python-dev postgresql-dev libxml2-dev libxslt-dev jpeg-dev zlib-dev && \
+    pip install --upgrade pip
+
+COPY . /app
+WORKDIR /app
+
+ENV LIBRARY_PATH /lib:/usr/lib
+
+RUN pip install -r requirements.txt && \
+    pip install --index-url https://code.stripe.com --upgrade stripe && \
+    mkdir logs
+
+EXPOSE 80
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine
 RUN apk upgrade --update && \
-    apk add build-base py-pip python-dev postgresql-dev libxml2-dev libxslt-dev jpeg-dev zlib-dev && \
+    apk add build-base py-pip python postgresql-libs libxml2 libxslt jpeg zlib nodejs \
+      python-dev postgresql-dev libxml2-dev libxslt-dev jpeg-dev zlib-dev && \
     pip install --upgrade pip
 
 COPY . /app
@@ -10,6 +11,8 @@ ENV LIBRARY_PATH /lib:/usr/lib
 
 RUN pip install -r requirements.txt && \
     pip install --index-url https://code.stripe.com --upgrade stripe && \
+    apk del build-base python-dev postgresql-dev libxml2-dev libxslt-dev jpeg-dev zlib-dev && \
+    rm -rf .git ~/.pip/cache && \
     npm install -g less && \
     cd client && npm install && \
     node_modules/.bin/webpack --config webpack.prod.config.js

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,15 +4,17 @@ services:
     image: postgres
     environment:
       POSTGRES_DB: modernomadb
+    volumes:
+    - /var/lib/modernomad-postgres:/var/lib/postgres
   mq:
     image: rabbitmq
   web:
     build: .
     ports:
-      - "${MODERNOMAD_PORT}:80"
+    - "${MODERNOMAD_PORT}:80"
     command: ./docker-entrypoint.sh
     volumes:
-      - /var/lib/modernomad:/var/lib/modernomad
+    - /var/lib/modernomad:/var/lib/modernomad
     depends_on:
-      - db
-      - mq
+    - db
+    - mq

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '2'
+services:
+  db:
+    image: postgres
+    environment:
+      POSTGRES_DB: modernomadb
+  mq:
+    image: rabbitmq
+  web:
+    build: .
+    ports:
+      - "${MODERNOMAD_PORT}:80"
+    command: ./docker-entrypoint.sh
+    volumes:
+      - /var/lib/modernomad:/var/lib/modernomad
+    depends_on:
+      - db
+      - mq

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+until python manage.py syncdb --noinput; do
+  >&2 echo "Postgres is unavailable - sleeping"
+  sleep 1
+done
+python manage.py makemigrations --noinput && \
+python manage.py migrate --noinput && \
+celery beat -b mq -A modernomad --detach && \
+python manage.py runserver 0.0.0.0:80 -v 3

--- a/modernomad/local_settings.docker.py
+++ b/modernomad/local_settings.docker.py
@@ -1,0 +1,137 @@
+# copy this file to local_settings.py. it should be exluded from the repo
+# (ensure local_settings.py is in .gitignore)
+
+# Make this unique, and don't share it with anybody.
+SECRET_KEY = 'secret'
+
+ADMINS = (
+          ('Your Name', 'your@email.com'),
+          )
+
+ALLOWED_HOSTS=['domain.com']
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': 'modernomadb',
+        'USER': 'postgres',
+        'HOST': 'db',
+        'PORT': 5432
+    }
+}
+
+MEDIA_ROOT = "/var/lib/modernomad/media/"
+BACKUP_ROOT= "/var/lib/modernomad/backups/"
+BACKUP_COUNT = 30
+
+# use XS_SHARING_ALLOWED_ORIGINS = '*' for all domains
+XS_SHARING_ALLOWED_ORIGINS = "http://localhost:8989/"
+XS_SHARING_ALLOWED_METHODS = ['POST','GET', 'PUT', 'OPTIONS', 'DELETE']
+XS_SHARING_ALLOWED_HEADERS = ["Content-Type"]
+
+# what mode are we running in? use this to trigger different settings.
+DEVELOPMENT = 0
+PRODUCTION = 1
+
+# default mode is production. change to dev as appropriate.
+MODE = PRODUCTION
+
+# how many days should people be allowed to make a reservation request for?
+MAX_RESERVATION_DAYS = 14
+
+# how many days ahead to send the welcome email to guests with relevan house
+# info.
+WELCOME_EMAIL_DAYS_AHEAD = 2
+
+# this should be a TEST or PRODUCTION key depending on whether this is a local
+# test/dev site or production!
+STRIPE_SECRET_KEY = "sk_XXXXX"
+STRIPE_PUBLISHABLE_KEY = "pk_XXXXX"
+
+# Discourse discussion group
+DISCOURSE_BASE_URL = 'http://your-discourse-site.com'
+DISCOURSE_SSO_SECRET = 'paste_your_secret_here'
+
+MAILGUN_API_KEY = "key-XXXX"
+
+LIST_DOMAIN = "somedomain.com"
+
+if MODE == DEVELOPMENT:
+	EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+	DEBUG=True
+else:
+	EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+	EMAIL_USE_TLS = True
+	EMAIL_HOST = 'somehost'
+	EMAIL_PORT = 587
+	EMAIL_HOST_USER = 'some@email.com'
+	EMAIL_HOST_PASSWORD = 'password'
+	DEBUG=False
+
+TEMPLATE_DEBUG = DEBUG
+
+# fill in any local template directories. any templates with the same name WILL
+# OVERRIDE included templates. don't forget the trailing slash in the path, and
+# a comma at the end of the tuple item if there is only one path.
+LOCAL_TEMPLATE_DIRS = (
+                       # eg, "../local_templates/",
+                       )
+
+# celery configuration options
+BROKER_URL = 'amqp://'
+CELERY_RESULT_BACKEND = 'amqp://'
+
+CELERY_TASK_SERIALIZER = 'json'
+CELERY_RESULT_SERIALIZER = 'json'
+CELERY_ENABLE_UTC = True
+
+# Logging
+LOGGING = {
+        'version': 1,
+        'disable_existing_loggers': False,
+        'formatters': {
+            'verbose': {
+                'format' : "[%(asctime)s] %(levelname)s [%(name)s:%(lineno)s] %(message)s",
+                'datefmt' : "%d/%b/%Y %H:%M:%S"
+                },
+            'simple': {
+                'format': '%(levelname)s %(message)s'
+                },
+            },
+        'handlers': {
+            'console': {
+                'level': 'DEBUG',
+                'class': 'logging.StreamHandler',
+                },
+            'mail_admins': {
+                'level': 'ERROR',
+                'class': 'django.utils.log.AdminEmailHandler',
+                'include_html': True,
+                'formatter': 'verbose',
+                }
+            },
+        'loggers': {
+            'django': {
+                'handlers': ['console'],
+                'level': 'INFO',
+                'propagate': True,
+                },
+            'django.request': {
+                'handlers': ['console', 'mail_admins'],
+                'level': 'INFO',
+                'propagate': True,
+                },
+            'core': {
+                'handlers': ['console'],
+                'level': 'DEBUG',
+                },
+            'modernomad': {
+                'handlers': ['console'],
+                'level': 'DEBUG',
+                },
+            'gather': {
+                'handlers': ['console'],
+                'level': 'DEBUG',
+                },
+            },
+        }

--- a/modernomad/local_settings.docker.py
+++ b/modernomad/local_settings.docker.py
@@ -1,6 +1,12 @@
 # copy this file to local_settings.py. it should be exluded from the repo
 # (ensure local_settings.py is in .gitignore)
 
+import os
+
+# Make filepaths relative to settings.
+ROOT = os.path.dirname(os.path.abspath(__file__))
+BASE_DIR = os.path.normpath(ROOT + '/..')
+
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = 'secret'
 
@@ -25,7 +31,7 @@ BACKUP_ROOT= "/var/lib/modernomad/backups/"
 BACKUP_COUNT = 30
 
 # use XS_SHARING_ALLOWED_ORIGINS = '*' for all domains
-XS_SHARING_ALLOWED_ORIGINS = "http://localhost:8989/"
+XS_SHARING_ALLOWED_ORIGINS = "http://localhost/"
 XS_SHARING_ALLOWED_METHODS = ['POST','GET', 'PUT', 'OPTIONS', 'DELETE']
 XS_SHARING_ALLOWED_HEADERS = ["Content-Type"]
 
@@ -84,6 +90,13 @@ CELERY_RESULT_BACKEND = 'amqp://'
 CELERY_TASK_SERIALIZER = 'json'
 CELERY_RESULT_SERIALIZER = 'json'
 CELERY_ENABLE_UTC = True
+
+WEBPACK_LOADER = {
+    'DEFAULT': {
+        'BUNDLE_DIR_NAME': 'client/dist/',
+        'STATS_FILE': os.path.join(BASE_DIR, 'client/webpack-stats-prod.json'),
+    }
+}
 
 # Logging
 LOGGING = {

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,5 +1,3 @@
-behave
-django-behave
 factory_boy
 splinter
 selenium

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ django-graphiql
 django-compressor
 icalendar
 django-ical
+django-behave
 
 # the stripe library requires custom arguments which the requirements.txt file
 # parsing apparently doesn't support, so install it manually on the command


### PR DESCRIPTION
Braindead simple way of doing a Docker + Docker Compose setup with modernomad. The user still has to create their own local_settings.py and set up their Django superuser. I have provided local_settings.docker.py as an example config for Docker usage. Simple instructions for use, after installing Docker and Docker Compose:

``` sh
git clone https://github.com/halfspiral/modernomad -b docker
cd modernomad
cp modernomad/local_settings.docker.py modernomad/local_settings.py
vim modernomad/local_settings.py  # add your config settings here
docker-compose up -d              # app is now available at localhost:8000
docker exec -it modernomad_web_1 python manage.py createsuperuser
```

To rebuild the app after config or code changes:

```
docker-compose up -d --build web
```

To change what port is used or where the volumes are mounted, it is suggested to edit the docker-compose.yml file:

``` yaml
    ports:
      - '8000:8000'                              # change to '80:8000' to use port 80
    volumes:
      - /var/lib/modernomad:/var/lib/modernomad  # change me too if you want
```

None of this documentation is included in any files in the PR. Perhaps it should be?
