### PR TITLE
Install/Run Documentatin Updates

### DIFF
--- a/client/server.js
+++ b/client/server.js
@@ -6,7 +6,8 @@ new WebpackDevServer(webpack(config), {
   publicPath: config.output.publicPath,
   hot: true,
   inline: true,
-  historyApiFallback: true
+  historyApiFallback: true,
+  public: 'YOUR_HOST_NAME_OR_IP'
 }).listen(3000, '0.0.0.0', function (err, result) {
   if (err) {
     console.log(err)

--- a/client/server.js
+++ b/client/server.js
@@ -7,7 +7,7 @@ new WebpackDevServer(webpack(config), {
   hot: true,
   inline: true,
   historyApiFallback: true,
-  public: 'YOUR_HOST_NAME_OR_IP'
+  public: 'localhost'
 }).listen(3000, '0.0.0.0', function (err, result) {
   if (err) {
     console.log(err)

--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -29,7 +29,7 @@ Install the `wget` tool, which is not installed on OS X by default:
 
 (Dev environment instructions for Linux missing)
 
-## Pip and Virtualenv, Python-Dev
+## Pip and Virtualenv, Python Libs
 
 Pip is Python's package manager, and virtualenv is a tool that lets you create
 self-contained environments for sets of python libraries. 
@@ -60,10 +60,9 @@ add these to your ~/.bashrc (~/.bash_profile if one OS X) (create this file if i
 don't forget to source the bashrc file now:
 - `source ~/.bashrc` (or `source ~/.bash_profile` if that's the file you used)
 
-you also need the python dev package:
-
-- `sudo apt-get install python-dev`
-
+Required Python Libs:
+OSX: ???
+Debian: `sudo apt-get install python-dev libxslt-dev libxml2-dev`
 
 ### PIL
 PIL is a requirement, but in order for it to compile with JPG support, you must have a system-wide library called libjpeg62-dev. 

--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -1,5 +1,11 @@
 
-## OS X requirements
+# Environment Setup
+
+These docs support OSX and Debian based OS's only from Debian 8 Jessie onwards (this would include Ubuntu 14.04LTS onwards), but instructions should map easily to other distrubutions.
+
+## Dev Environment Requirements
+
+### OSX
 
 These are only necessary for OS X devs. You will need Xcode, Xcode command line
 tools, and brew.
@@ -19,7 +25,11 @@ Install the `wget` tool, which is not installed on OS X by default:
 
 - `brew install wget`
 
-## Pip and Virtualenv. 
+### Linux
+
+(Dev environment instructions for Linux missing)
+
+## Pip and Virtualenv, Python-Dev
 
 Pip is Python's package manager, and virtualenv is a tool that lets you create
 self-contained environments for sets of python libraries. 
@@ -50,12 +60,15 @@ add these to your ~/.bashrc (~/.bash_profile if one OS X) (create this file if i
 don't forget to source the bashrc file now:
 - `source ~/.bashrc` (or `source ~/.bash_profile` if that's the file you used)
 
-## Dependencies
+you also need the python dev package:
+
+- `sudo apt-get install python-dev`
+
 
 ### PIL
 PIL is a requirement, but in order for it to compile with JPG support, you must have a system-wide library called libjpeg62-dev. 
 
-**On OS X**
+#### OS X
 
 Install the missing libjpeg library. You will need X Code installed with the
 extra "command line tools" component as described above. 
@@ -67,36 +80,33 @@ extra "command line tools" component as described above.
 	* `./configure`
 	* `make`
 	* `sudo make install`
- 
 
-**On Linux**
+Then either install PIL using `brew`, or from the dmg's available on the PIL website. for example, see the process outlined [here](http://stackoverflow.com/questions/9070074/how-to-install-pil-on-mac-os-x-10-7-2-lion)
 
-- `sudo apt-get install libjpeg62-dev`
+#### Debian
 
-you also need the python dev package:
+- `sudo apt-get install libjpeg62-turbo-dev`
 
-- `sudo apt-get install python-dev`
+Old docs, not required for jessie? remove this section?
 
-you may need to symlink these libraries for PIL to find them during the install:
+> you may need to symlink these libraries for PIL to find them during the install:
+>
+> `sudo ln -s /usr/lib/x86_64-linux-gnu/libfreetype.so /usr/lib/`
+> `sudo ln -s /usr/lib/x86_64-linux-gnu/libz.so /usr/lib/`
+> `sudo ln -s /usr/lib/x86_64-linux-gnu/libjpeg.so /usr/lib/`
 
-`sudo ln -s /usr/lib/x86_64-linux-gnu/libfreetype.so /usr/lib/`
-`sudo ln -s /usr/lib/x86_64-linux-gnu/libz.so /usr/lib/`
-`sudo ln -s /usr/lib/x86_64-linux-gnu/libjpeg.so /usr/lib/`
-
-
-then either install PIL using `brew`, or from the dmg's available on the PIL website. for example, see the process outlined [here](http://stackoverflow.com/questions/9070074/how-to-install-pil-on-mac-os-x-10-7-2-lion)
 
 ### RabbitMQ
-celery depends on rabbit-mq, which can be installed using brew on OS X or
-apt-get on debian/ubuntu (and other ways on other systems). 
 
-- os x: `brew update; brew install rabbitmq`
-- debian/ubuntu: `sudo apt-get install rabbitmq-server`
+Required for Celery
+
+OSX: `brew update; brew install rabbitmq`
+Debian: `sudo apt-get install rabbitmq-server`
 
 ### PostgreSQL
 
-- os x: `brew update; brew install postgresql`
-- debian/ubuntu: `sudo apt-get install postgresql libpq-dev`
+OSX: `brew update; brew install postgresql`
+Debian: `sudo apt-get install postgresql libpq-dev`
 
 ## Hooray!
 

--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -60,6 +60,14 @@ add these to your ~/.bashrc (~/.bash_profile if one OS X) (create this file if i
 don't forget to source the bashrc file now:
 - `source ~/.bashrc` (or `source ~/.bash_profile` if that's the file you used)
 
+## Node
+
+### OSX
+???
+
+### Debian
+Install npm e.g. as per https://www.digitalocean.com/community/tutorials/how-to-install-node-js-on-debian-
+
 ## Required Libs:
 ### OSX
 ???

--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -29,7 +29,7 @@ Install the `wget` tool, which is not installed on OS X by default:
 
 (Dev environment instructions for Linux missing)
 
-## Pip and Virtualenv, Python Libs
+## Pip and Virtualenv
 
 Pip is Python's package manager, and virtualenv is a tool that lets you create
 self-contained environments for sets of python libraries. 
@@ -60,14 +60,17 @@ add these to your ~/.bashrc (~/.bash_profile if one OS X) (create this file if i
 don't forget to source the bashrc file now:
 - `source ~/.bashrc` (or `source ~/.bash_profile` if that's the file you used)
 
-Required Python Libs:
-OSX: ???
-Debian: `sudo apt-get install python-dev libxslt-dev libxml2-dev`
+## Required Libs:
+### OSX
+???
+### Debian
 
-### PIL
+`sudo apt-get install python-dev libxslt-dev libxml2-dev node-less`
+
+## PIL
 PIL is a requirement, but in order for it to compile with JPG support, you must have a system-wide library called libjpeg62-dev. 
 
-#### OS X
+### OS X
 
 Install the missing libjpeg library. You will need X Code installed with the
 extra "command line tools" component as described above. 
@@ -82,7 +85,7 @@ extra "command line tools" component as described above.
 
 Then either install PIL using `brew`, or from the dmg's available on the PIL website. for example, see the process outlined [here](http://stackoverflow.com/questions/9070074/how-to-install-pil-on-mac-os-x-10-7-2-lion)
 
-#### Debian
+### Debian
 
 - `sudo apt-get install libjpeg62-turbo-dev`
 
@@ -94,17 +97,20 @@ Old docs, not required for jessie? remove this section?
 > `sudo ln -s /usr/lib/x86_64-linux-gnu/libz.so /usr/lib/`
 > `sudo ln -s /usr/lib/x86_64-linux-gnu/libjpeg.so /usr/lib/`
 
+## Supporting Services
 
 ### RabbitMQ
 
 Required for Celery
 
 OSX: `brew update; brew install rabbitmq`
+
 Debian: `sudo apt-get install rabbitmq-server`
 
 ### PostgreSQL
 
 OSX: `brew update; brew install postgresql`
+
 Debian: `sudo apt-get install postgresql libpq-dev`
 
 ## Hooray!

--- a/docs/how-to-run.md
+++ b/docs/how-to-run.md
@@ -1,6 +1,6 @@
 ## How to Run the First Time
 
-Assuming you have all the prerequisites and dependencies outlined in [setup](setup.md), we can proceed with making the virtual environemnt, populating it with required libraries, getting your local configuration working and starting up the app.
+Assuming you have all the prerequisites and dependencies outlined in [environment-setup](environment-setup.md), we can proceed with making the virtual environemnt, populating it with required libraries, getting your local configuration working and starting up the app.
 
 ## virtualenv
 create a new virtual environment for this project:

--- a/docs/how-to-run.md
+++ b/docs/how-to-run.md
@@ -29,6 +29,7 @@ install all node packages
 
 initialize webpack here???
 - `node_modules/.bin/webpack --config webpack.prod.config.js`
+
 @todo This is a fix to make webpack work. Configuration needs tidying up by whoever knows how webpack works.
 - `cp webpack-stats-prod.json webpack-stats.json`
 
@@ -36,7 +37,8 @@ note that the stripe library requires custom arguments which the
 requirements.txt file parsing [apparently doesn't
 support](https://github.com/pypa/pip/pull/515) (as of november 2012), so
 install it manually on the command line using:
-`pip install --index-url https://code.stripe.com --upgrade stripe`
+
+- `pip install --index-url https://code.stripe.com --upgrade stripe`
 
 
 ## configuration file

--- a/docs/how-to-run.md
+++ b/docs/how-to-run.md
@@ -73,8 +73,11 @@ go back into the top level repository directory and do the following:
 - `./manage.py migrate` will initialise the database on first run
 
 ## run!
-now you should be able to run the software:
+now you should be able to run the software. Both django and node are required to be running!
+
 - `./manage.py runserver [port]`
+- `cd client`
+- `node server`
 
 the first time you run the software, you will want to configure two things in
 the admin interface. the software is designed to send various emails to users

--- a/docs/how-to-run.md
+++ b/docs/how-to-run.md
@@ -45,8 +45,7 @@ create your own local_settings.py file from local_settings.example.py. inside th
   * `CREATE DATABASE modernomad;`
   * `GRANT ALL PRIVILEGES ON DATABASE modernomad TO modernomad ;`
   * (Enter USER, NAME, and PASSWORD in config)
-* LOGGING: If some debug modes are enabled you need to set a valid log file path in the setting LOGGING.handlers.file.filename
-
+* `LOGGING` : If some debug modes are enabled you need to set a valid log file path in the setting LOGGING.handlers.file.filename
 
 ### optional stuff required for payment, email, etc. 
 

--- a/docs/how-to-run.md
+++ b/docs/how-to-run.md
@@ -32,7 +32,8 @@ initialize webpack here???
 
 @todo This is a fix to make webpack work. Configuration needs tidying up by whoever knows how webpack works.
 - `cp webpack-stats-prod.json webpack-stats.json`
-- Edit server.js and replace `YOUR_HOST_NAME_OR_IP` to the public IP address or hostname you are serving from. E.g. `public: 'myhousingnetwork.com'`
+- Edit server.js and replace `localhost` if necessary with the public IP address or hostname you are serving from. E.g. `public: 'myhousingnetwork.com'`
+- Edit webpack.config.js and in the output.publicPath setting, replace `localhost` if necessary with your public IP or hostname. E.g. ` publicPath: 'http://myhousingnetwork:3000/build/'`
 
 
 note that the stripe library requires custom arguments which the

--- a/docs/how-to-run.md
+++ b/docs/how-to-run.md
@@ -32,6 +32,8 @@ initialize webpack here???
 
 @todo This is a fix to make webpack work. Configuration needs tidying up by whoever knows how webpack works.
 - `cp webpack-stats-prod.json webpack-stats.json`
+- Edit server.js and replace `YOUR_HOST_NAME_OR_IP` to the public IP address or hostname you are serving from. E.g. `public: 'myhousingnetwork.com'`
+
 
 note that the stripe library requires custom arguments which the
 requirements.txt file parsing [apparently doesn't
@@ -106,15 +108,22 @@ to match the host and port you are running the software on.
 
 Now you can go ahead and start creating content. 
 
-## each time
+## Running in Production
 
-- make sure rabbitmq is running, or start it: `rabbitmq-server`
-- start celery beat (the scheduler for periodic tasks): `celery beat` (or some
+(Update docs here for Debian service creation)
+
+Ensure required services running:
+
+- rabbitmq
+- celery 
+   - `celery beat` (or some
   more sophisticated version of the same command, depending on your local or
   production setup), such as `./manage.py celeryd -v 2 -B -s celery -E -l INFO -n some_unique_name`
-- start django `./manage.py runserver domain port`
+- postgres
 
+Start django and node services
 
+(Docs here for adding proper production configuration for django and node)
 
 ## model updates
 see the instructions in [updates](updates.md) for how to create and run database migrations if you add or remove fields from models. 

--- a/docs/how-to-run.md
+++ b/docs/how-to-run.md
@@ -72,14 +72,22 @@ go back into the top level repository directory and do the following:
 
 - `./manage.py migrate` will initialise the database on first run
 
-## run!
-now you should be able to run the software. Both django and node are required to be running!
+## Run!
 
+Now you should be able to run the software. Both django and node are required to be running!
+
+Run django:
+
+- `cd $WORKON_HOME/modernomadenv/modernomad`
 - `./manage.py runserver [port]`
-- `cd client`
+
+Run node:
+
+- `cd $WORKON_HOME/modernomadenv/modernomad/client` 
 - `node server`
 
-the first time you run the software, you will want to configure two things in
+
+The first time you run the software, you will want to configure two things in
 the admin interface. the software is designed to send various emails to users
 who are part of the group 'house_admins' so, before it will send any emails,
 you need to add at least one user to this group. login to the admin interface

--- a/docs/how-to-run.md
+++ b/docs/how-to-run.md
@@ -29,24 +29,40 @@ install it manually on the command line using:
 `pip install --index-url https://code.stripe.com --upgrade stripe`
 
 
-## first time
+## configuration file
 create your own local_settings.py file from local_settings.example.py. inside the modernomad/modernomad directory, do the following:
 - `cp local_settings.example.py local_settings.py`
 
-the local_settings.py file contains configuration information for stripe
-(payment handling), and email. if you want to run the software on a production
-server, there are production-specific settings for email which you must setup
-if you want email to work. by default, the software is in "development" mode,
-and emails are sent using django's built-in console backend, meaning they
-get printed to the console. 
+### settings you must configure, and dependant services:
+
+* `SECRET_KEY` : Set this to a private string
+* `ADMINS`     : Enter publically viewabls name, email address of administrator of this whole installation
+* `ALLOWED_HOSTS` : Enter comma delimited list of all hostnames which this site may be served through. Can be IP address, should include both with and without 'www.' separately.
+* `DATABASES`  : Setup Postgres:
+  * `sudo su - postgres`
+  * `psql`
+  * `CREATE USER modernomad WITH PASSWORD '$POSTGRESPASSWORD';`
+  * `CREATE DATABASE modernomad;`
+  * `GRANT ALL PRIVILEGES ON DATABASE modernomad TO modernomad ;`
+  * (Enter USER, NAME, and PASSWORD in config)
+* LOGGING: If some debug modes are enabled you need to set a valid log file path in the setting LOGGING.handlers.file.filename
+
+
+### optional stuff required for payment, email, etc. 
+
+* STRIPE
+* EMAIL: if you want to run the software on a production server, there are production-specific settings for email which you must setup if you want email to work. by default, the software is in "development" mode, and emails are sent using django's built-in console backend, meaning they get printed to the console. 
 
 - browse through settings.py. make note of the location of the media directory and media_url, and any other settings of interest.
+
+## initialisation
 
 go back into the top level repository directory and do the following:
 
 - run `./manage.py syncdb` to create and sync the models of installed apps (and create an admin user)
 - run `./manage.py migrate` to run the existing migrations (this will run migrations for all apps)
 
+## run!
 now you should be able to run the software:
 - `./manage.py runserver [port]`
 

--- a/docs/how-to-run.md
+++ b/docs/how-to-run.md
@@ -21,6 +21,8 @@ installed in the virtual env.
 ## dependencies:
 within the virtualenv, install the requirements. this is done with the following command, which should iterate through the items in the text file and install them one by one:
 - `pip install -r requirements.txt` 
+- `pip install -r requirements.test.txt` 
+
 
 note that the stripe library requires custom arguments which the
 requirements.txt file parsing [apparently doesn't
@@ -58,8 +60,7 @@ create your own local_settings.py file from local_settings.example.py. inside th
 
 go back into the top level repository directory and do the following:
 
-- run `./manage.py syncdb` to create and sync the models of installed apps (and create an admin user)
-- run `./manage.py migrate` to run the existing migrations (this will run migrations for all apps)
+- `./manage.py migrate` will initialise the database on first run
 
 ## run!
 now you should be able to run the software:

--- a/docs/how-to-run.md
+++ b/docs/how-to-run.md
@@ -23,6 +23,14 @@ within the virtualenv, install the requirements. this is done with the following
 - `pip install -r requirements.txt` 
 - `pip install -r requirements.test.txt` 
 
+install all node packages
+- `cd modernomad/client`
+- `npm install`
+
+initialize webpack here???
+- `node_modules/.bin/webpack --config webpack.prod.config.js`
+@todo This is a fix to make webpack work. Configuration needs tidying up by whoever knows how webpack works.
+- `cp webpack-stats-prod.json webpack-stats.json`
 
 note that the stripe library requires custom arguments which the
 requirements.txt file parsing [apparently doesn't

--- a/modernomad/settings.py
+++ b/modernomad/settings.py
@@ -161,6 +161,7 @@ INSTALLED_APPS = (
     'webpack_loader',
     'compressor',
     'django_extensions',
+    'django_filters',
     # 'debug_toolbar',
 )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
-#Django>=1.10,<1.11
 Django>=1.9.12,<1.10
-# Django>=1.8.8,<1.9
 amqp==1.4.9
 anyjson==0.3.3
 billiard==3.3.0.23
@@ -24,8 +22,11 @@ django-jwt-auth
 django-webpack-loader==0.3.3
 djangorestframework
 markdown
-django-filter
-graphene-django>=1.0.dev
+django-filter==0.15.3
+graphene==1.0
+graphene-django==1.1.0
+graphql-core==1.1
+graphql-relay==0.4.5
 django-graphiql
 django-compressor
 icalendar


### PR DESCRIPTION
Lots of changes here where I tidied up and added to the docs as I was doing an install on Debian. Particular bits of note:

- If using all latest versions of the packages in requirements.txt an requirements.test.txt, there are issues with the codebase using features that have been removed from graphene and django-filters. I have set specific older versions of some packages that support those features.

- The node/webpack stuff was completely missing from docs. I don't know anything about node/webpack so made minimum hacks to config and docs to allow someone else to get it working. The docs/config I did needs review by whoever knows about node/webpack.