### PR TITLE
Add Docker development environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ django.log
 modernomad.komodoproject
 modernomad/local_settings.py.bak
 ghostdriver.log
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM python:2-alpine
+
+# So Pillow can find zlib
+ENV LIBRARY_PATH /lib:/usr/lib
+
+RUN apk add --no-cache \
+  build-base \
+  jpeg \
+  jpeg-dev \
+  libxslt \
+  libxslt-dev \
+  libxml2 \
+  libxml2-dev \
+  nodejs \
+  postgresql-dev \
+  postgresql-libs \
+  zlib \
+  zlib-dev
+
+RUN npm install -g less
+
+# Only copy requirements so cache isn't busted by changes in the app
+RUN mkdir -p /app
+COPY requirements.txt requirements.test.txt /app/
+WORKDIR /app
+RUN pip install --no-cache-dir -r requirements.txt -r requirements.test.txt
+
+ENV DJANGO_SETTINGS_MODULE modernomad.settings_docker
+EXPOSE 8000
+
+COPY . /app/
+
+CMD ["./manage.py", "runserver", "0.0.0.0:8000"]

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:8-alpine
+RUN mkdir -p /app
+WORKDIR /app
+COPY package.json /app/
+RUN npm install && npm cache clean --force
+COPY . /app/
+EXPOSE 3000
+RUN ["node", "server.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,49 @@
+version: "3.0"
+services:
+  web:
+    build: .
+    ports:
+      - "8000:8000"
+    environment:
+      - "BROKER_URL=amqp://guest:guest@rabbitmq//"
+      - "DATABASE_URL=postgres://postgres@postgres/postgres"
+      - "SECRET_KEY=insecure - only for development"
+      - "STRIPE_SECRET_KEY"
+      - "STRIPE_PUBLISHABLE_KEY"
+      - "DISCOURSE_BASE_URL"
+      - "DISCOURSE_SSO_SECRET"
+      - "MAILGUN_API_KEY"
+    links:
+      - postgres
+      - rabbitmq
+    volumes:
+      - "./:/app"
+  client:
+    build: client/
+    ports:
+      - "3000:3000"
+    # Bind mount app directory, but leave node_modules intact
+    volumes:
+      - "./client/:/app"
+      - "/app/node_modules"
+  celery:
+    build: .
+    command: ./manage.py celeryd --verbosity=2 --beat --schedule=celery --events --loglevel=INFO
+    environment:
+      - "BROKER_URL=amqp://guest:guest@rabbitmq//"
+      - "DATABASE_URL=postgres://postgres@postgres/postgres"
+      - "SECRET_KEY=insecure - only for development"
+      - "STRIPE_SECRET_KEY"
+      - "STRIPE_PUBLISHABLE_KEY"
+      - "DISCOURSE_BASE_URL"
+      - "DISCOURSE_SSO_SECRET"
+      - "MAILGUN_API_KEY"
+    links:
+      - postgres
+      - rabbitmq
+    volumes:
+      - "./:/app"
+  rabbitmq:
+    image: rabbitmq
+  postgres:
+    image: postgres

--- a/docs/docker-development-environment.md
+++ b/docs/docker-development-environment.md
@@ -1,0 +1,34 @@
+# Docker Development Environment
+
+First, install Docker CE. On macOS, the best way to this is to use [Docker for Mac](https://docs.docker.com/docker-for-mac/install/). For Linux and Windows, [take a look at Docker's documentation](https://docs.docker.com/engine/installation/).
+
+Next, run:
+
+    $ docker-compose up --build
+
+This will boot up everything that Modernomad needs to run.
+
+In another console, run these commands to set up the database and set up a user:
+
+    $ docker-compose run web ./manage.py migrate
+    $ docker-compose run web ./manage.py createsuperuser
+
+You only need to run these commands once. To spin up the development environment when you need to work on it again, just run `docker-compose up --build`. (Note: `--build` is optional, but means that the Python and Node dependencies will always remain up-to-date.)
+
+To run the test suite:
+
+    $ docker-compose run web ./manage.py test
+
+## Configuration
+
+You can configure the development environment using environment variables in a file called `.env`. It looks something like this:
+
+```
+STRIPE_SECRET_KEY=...
+STRIPE_PUBLISHABLE_KEY=...
+DISCOURSE_BASE_URL=...
+DISCOURSE_SSO_SECRET=...
+MAILGUN_API_KEY=...
+```
+
+To learn about what can be configured, see the [configuration documentation](configuration.md).

--- a/modernomad/settings_docker.py
+++ b/modernomad/settings_docker.py
@@ -1,0 +1,60 @@
+# A sensible set of defaults for a development environment, that can be
+# overridden with environment variables
+
+import environ
+from django.core.exceptions import ImproperlyConfigured
+from .settings import *
+
+env = environ.Env()
+
+# what mode are we running in? use this to trigger different settings.
+DEVELOPMENT = 0
+PRODUCTION = 1
+
+# default mode is production. change to dev as appropriate.
+env_mode = env('MODE', default='DEVELOPMENT')
+if env_mode == 'DEVELOPMENT':
+    MODE = DEVELOPMENT
+    DEBUG = True
+    EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+elif env_mode == 'PRODUCTION':
+    MODE = PRODUCTION
+else:
+    raise ImproperlyConfigured('Unknown MODE setting')
+
+TEMPLATE_DEBUG = DEBUG
+
+SECRET_KEY = env('SECRET_KEY')
+DATABASES = {
+    'default': env.db(),
+}
+
+BROKER_URL = env('BROKER_URL', default='amqp://')
+CELERY_RESULT_BACKEND = env('BROKER_URL', default='amqp://')
+
+# this should be a TEST or PRODUCTION key depending on whether this is a local
+# test/dev site or production!
+STRIPE_SECRET_KEY = env('STRIPE_SECRET_KEY', default='')
+STRIPE_PUBLISHABLE_KEY = env('STRIPE_PUBLISHABLE_KEY', default='')
+
+# Discourse discussion group
+DISCOURSE_BASE_URL = env('DISCOURSE_BASE_URL', default='')
+DISCOURSE_SSO_SECRET = env('DISCOURSE_SSO_SECRET', default='')
+
+MAILGUN_API_KEY = env('MAILGUN_API_KEY', default='')
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'loggers': {
+        'django': {
+            'handlers': ['console'],
+            'level': env('DJANGO_LOG_LEVEL', default='INFO'),
+        },
+    },
+}

--- a/readme.md
+++ b/readme.md
@@ -3,18 +3,18 @@
 Modernomad is an operating platform for collaborative spaces. It aims to
 facilitate democratic management, empower people with information, and enable
 meaningful connections for groups that value openness, collaboration and
-participation. 
+participation.
 
 Main features include profiles, mailing lists, guest and booking
 management, events, static content, and community management. A [detailed
-feature list](docs/features.md) is also available. 
+feature list](docs/features.md) is also available.
 
 ## License
 Modernomad is licensed under the [Affero General Public License](agpl-3.0.txt),
 which is like the GPL but requires you provide access to the source code for
 any modified versions that are running publicly (among other things). The
 [intent](http://www.gnu.org/licenses/why-affero-gpl.html) is for anyone
-improving the software makes those improvements available to others. 
+improving the software makes those improvements available to others.
 
 <img src="static/img/agplv3-88x31.png" />
 
@@ -25,14 +25,16 @@ Interested in contributing? We use [Trello](https://trello.com/b/FPDnTkqj/modern
 associated with this repository if you are not on trello and want to report problems, bugs or make suggestions.
 [Read more about contributing](docs/contributing.md).
 
-### Pre-requisites, system dependencies and environment setup intructions:
-see [Environment Setup](docs/environment-setup.md)
+### Docker development environment
 
-### First-time Setup
-see [How to Run](docs/how-to-run.md)
+The easiest way to get up and running in development is by using Docker. See [Docker development environment](docs/docker-development-environment.md).
+
+### Manual setup
+
+If you can't or don't want to use Docker, see [Environment Setup](docs/environment-setup.md) and [How to Run](docs/how-to-run.md).
 
 ### Configuration
+
 see [Configuration](docs/configuration.md)
 
-Additional docs also to be found in the [`docs`](docs/) directory. 
-
+Additional documentation can be found in the [`docs`](docs/) directory.

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,7 @@ icalendar
 django-ical
 django-extensions
 Werkzeug
+django-environ==0.4.3
 
 # the stripe library requires custom arguments which the requirements.txt file
 # parsing apparently doesn't support, so install it manually on the command


### PR DESCRIPTION
I've added a Docker development environment, loosely based on #259  . This is cool because:

* You can boot up the entire stack with a single command and aggregate the output in the console
* It's completely isolated
* Code is mounted inside the Docker containers and FS events are passed through so you can update files like you would on your local machine
* Unlike Vagrant, it isn't really slow and doesn't use up loads of disk space

I have also made a start at exposing Modernomad settings as environment variables so it works as a 12-factor app. (Docker is much happier when you can configure things with envvars.) In theory this could just be put in the main `settings.py`, but I didn't do this out of fear of breaking existing setups. This might make sense for some future refactoring.

It works a bit like this:

![compose-modernomad](https://user-images.githubusercontent.com/40906/28240901-876787ec-6981-11e7-8b84-9de1c336684c.gif)

:tada: