### PR TITLE
Disable migrations for tests

### DIFF
--- a/modernomad/settings.py
+++ b/modernomad/settings.py
@@ -1,6 +1,7 @@
 # Django settings for modernomad project.
 import os
 import datetime
+import sys
 
 # Make filepaths relative to settings.
 ROOT = os.path.dirname(os.path.abspath(__file__))
@@ -210,5 +211,22 @@ NOSE_ARGS = [
     '--nocapture',
     '--nologcapture'
 ]
+
+
+class DisableMigrations(object):
+    def __contains__(self, item):
+        return True
+
+    def __getitem__(self, item):
+        return None
+
+
+TESTS_IN_PROGRESS = False
+if 'test' in sys.argv[1:]:
+    PASSWORD_HASHERS = (
+        'django.contrib.auth.hashers.MD5PasswordHasher',
+    )
+    TESTS_IN_PROGRESS = True
+    MIGRATION_MODULES = DisableMigrations()
 
 os.environ['DJANGO_LIVE_TEST_SERVER_ADDRESS'] = "localhost:8000-8010,8080,9200-9300"


### PR DESCRIPTION
This dramatically speeds up tests. The downside is that data
migrations aren't run for tests, which is just something we have
be aware of.

So, for example, we can't set up fixtures using data migrations.
(Ironically I did that in the first PR I made, but it doesn't
seem to break the tests so ¯\_(ツ)_/¯)