### PR TITLE
Fix special characters breaking usernames

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import User
 from django import forms
+from django.utils.text import slugify
 from django.utils.translation import ugettext_lazy as _
 from PIL import Image
 import os
@@ -105,16 +106,11 @@ class UserProfileForm(forms.ModelForm):
         return email
 
     def create_username(self, suffix=""):
-        clean_first = self.cleaned_data['first_name'].strip().lower()
-        clean_last = self.cleaned_data['last_name'].strip().lower()
-        username = "%s_%s%s" % (clean_first, clean_last, suffix)
-        clean_username = username.replace(" ", "_")
-        clean_username = clean_username.replace(".", "_")
-        clean_username = clean_username.replace("@", "")
-        clean_username = clean_username.replace("+", "")
-        clean_username = clean_username.replace("-", "")
-        clean_username = clean_username.replace("'", "")
-        return clean_username
+        return slugify("%s %s%s" % (
+            self.cleaned_data['first_name'],
+            self.cleaned_data['last_name'],
+            suffix
+        ))
 
     def clean(self):
         # Generate a (unique) username, if one is needed (ie, if the user is new)

--- a/core/tests/test_forms.py
+++ b/core/tests/test_forms.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+from django.test import TestCase
+from core.forms import UserProfileForm
+
+
+class UserProfileFormTest(TestCase):
+    def test_create_username(self):
+        form = UserProfileForm({
+            'first_name': 'Joe',
+            'last_name': '⛄️ Bloggs',
+        })
+        form.is_valid()
+        self.assertEqual(form.cleaned_data['username'], 'joe-bloggs')


### PR DESCRIPTION
I've just used Django's built-in slugify. The main difference this makes is that spaces are "-" instead of "_". I prefer this stylistically (and is the normal Django style) but this can easily be changed back to underscores if you'd prefer.

Also, I have intentionally not done a data migration, because changing everyone's username sounds scary and breaky. A safer alternative could be to just migrate usernames with non-alphanumeric characters, but I'm not sure if this is worth bothering with? Presumably everybody that has a broken username has already had it fixed?

Fixes #281 