### PR TITLE
On login links, pass the current url as next

### DIFF
--- a/gather/templates/gather_event_view.html
+++ b/gather/templates/gather_event_view.html
@@ -30,7 +30,7 @@
             </div>
             <div class="modal-body">
                 <h4>We need a bit more info to keep you posted on this event. </h4>
-                <p><em>Already a member? <a href="{% url 'user_login' %}">Login instead</a></em></p>
+                <p><em>Already a member? <a href="{% url 'user_login' %}?next={ request.path|urlencode }">Login instead</a></em></p>
                 <div id="new-user-form-errors"></div>
                 <form id="new-user-form" class="form-horizontal">
                     <div class="form-group">
@@ -258,7 +258,7 @@
             password2: "The passwords do not match.",
             email: {
                 strictEmail: "Please provide a valid email address.",
-                remote: "This email address is already in use. If you need to log in, please visit the <a href='{% url 'user_login' %}'>login</a> page."
+                remote: "This email address is already in use. If you need to log in, please visit the <a href='{% url 'user_login' %}?next={ request.path|urlencode }'>login</a> page."
             },
             username: {
                 remote: "This username is already taken. Please choose another."

--- a/templates/registration/registration_form.html
+++ b/templates/registration/registration_form.html
@@ -268,7 +268,7 @@
             },
             email: {
                 strictEmail: "Please provide a valid email address.",
-                remote: "This email address is already in use. If you need to log in, please visit the <a href='{% url 'user_login' %}'>login</a> page."
+                remote: "This email address is already in use. If you need to log in, please visit the <a href='{% url 'user_login' %}?next={ request.path|urlencode }'>login</a> page."
             },
         },
         rules: {


### PR DESCRIPTION
This means that the logged-in user will be sent to the source
page, which is super convenient, e.g. when registering for events.