### PR TITLE
Use stripe package from PyPi

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -80,7 +80,6 @@ $userScript = <<SCRIPT
 
   mkvirtualenv modernomad
   yes | pip install -r requirements.txt
-  yes | pip install --index-url https://code.stripe.com --upgrade stripe
 
   if [ ! -f modernomad/local_settings.py ]; then
   	SECURE_RANDOM=$(dd if=/dev/urandom count=1 bs=28 2>/dev/null | od -t x1 -A n)

--- a/conf/setup.txt
+++ b/conf/setup.txt
@@ -36,7 +36,6 @@ source bin/activate
 git clone https://github.com/jessykate/modernomad.git
 cd modernomad
 pip install -r requirements.txt
-pip install --index-url https://code.stripe.com --upgrade stripe
 pip install gunicorn
 pip install psycopg2
 

--- a/core/payment_gateway.py
+++ b/core/payment_gateway.py
@@ -93,19 +93,14 @@ def stripe_charge_user(user, bill, amount_dollars, reference):
             description= reference
         )
 
-    logger.debug('charge obj')
-    logger.debug(charge)
-    logger.debug('--- charge.card.last4')
-    logger.debug(charge.card.last4)
-
     # Store the charge details in a Payment object
     return Payment.objects.create(bill=bill,
         user = user,
         payment_service = "Stripe",
-        payment_method = charge.card.brand,
+        payment_method = charge.source.brand,
         paid_amount = amount_dollars,
         transaction_id = charge.id,
-        last4 = charge.card.last4
+        last4 = charge.source.last4
     )
 
 def stripe_charge_booking(booking):
@@ -126,19 +121,14 @@ def stripe_charge_booking(booking):
             description=descr
         )
 
-    print 'charge obj'
-    print charge
-    print '--- charge.card.last4'
-    print charge.card.last4
-
     # Store the charge details in a Payment object
     return Payment.objects.create(bill=booking.bill,
         user = booking.use.user,
         payment_service = "Stripe",
-        payment_method = charge.card.brand,
+        payment_method = charge.source.brand,
         paid_amount = amt_owed,
         transaction_id = charge.id,
-        last4 = charge.card.last4
+        last4 = charge.source.last4
     )
 
 def stripe_issue_refund(payment, refund_amount=None):

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,6 +25,16 @@ The majority of the configuration is around
   connected with the house and its activities. They are sent to guests in the
   welcome email so make sure to populate these. 
 
+## Stripe in development
+
+If you want to test Stripe payments, you need to set up an account and get some test keys.
+
+First, [create an account](https://dashboard.stripe.com/register). On the left-hand menu, click "Developers", then "API Keys".
+
+**Important:** Make sure the keys start with `pk_test_` and `sk_test_` otherwise you will be charging real credit cards!
+
+Copy and paste these keys into your `local_settings.py` file. If you're using Docker, they go in the `.env` file.
+
 ## Local Settings
 
 - While getting set up, leave the MODE set to DEVELOPMENT

--- a/docs/how-to-run.md
+++ b/docs/how-to-run.md
@@ -36,14 +36,6 @@ initialize webpack here???
 - Edit webpack.config.js and in the output.publicPath setting, replace `localhost` if necessary with your public IP or hostname. E.g. ` publicPath: 'http://myhousingnetwork:3000/build/'`
 
 
-note that the stripe library requires custom arguments which the
-requirements.txt file parsing [apparently doesn't
-support](https://github.com/pypa/pip/pull/515) (as of november 2012), so
-install it manually on the command line using:
-
-- `pip install --index-url https://code.stripe.com --upgrade stripe`
-
-
 ## configuration file
 create your own local_settings.py file from local_settings.example.py. inside the modernomad/modernomad directory, do the following:
 - `cp local_settings.example.py local_settings.py`

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ python-mimeparse==0.1.4
 pytz==2015.7
 requests==2.9.1
 six==1.10.0
-stripe
+stripe==2.10.1
 django-jwt-auth==0.0.2
 django-webpack-loader==0.3.3
 djangorestframework==3.6.4
@@ -34,8 +34,3 @@ django-ical==1.5
 django-extensions==2.1.3
 Werkzeug==0.14.1
 django-environ==0.4.3
-
-# the stripe library requires custom arguments which the requirements.txt file
-# parsing apparently doesn't support, so install it manually on the command
-# line using:
-# pip install --index-url https://code.stripe.com --upgrade stripe


### PR DESCRIPTION
The packages on code.stripe.com and pypi.python.org seem identical, so this is probably an artefact from some point in the past when they were not. (It says "as of november 2012" in one of the documentation files!)

This might have been done for some undocumented reason that is still valid though. @jessykate @craigambrose - do you know?