### PR TITLE
Docker in production

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+media
+.env
+client/node_modules
+client/build
+client/webpack-stats.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   - "pip install -r requirements.txt -r requirements.test.txt"
 before_script:
   - "cd client && npm install && cd .."
-  - "cd client && webpack --config webpack.prod.config.js && cd .."
+  - "cd client && ./node_modules/.bin/webpack --config webpack.prod.config.js && cd .."
   - "cp modernomad/local_settings.travis.py modernomad/local_settings.py"
 script: ./manage.py test
 notifications:

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,9 +38,14 @@ RUN cd client && node_modules/.bin/webpack --config webpack.prod.config.js
 # Set configuration last so we can change this without rebuilding the whole
 # image
 ENV DJANGO_SETTINGS_MODULE modernomad.settings_docker
+ENV MODE PRODUCTION
+# Number of gunicorn workers
+ENV WEB_CONCURRENCY 3
 EXPOSE 8000
+CMD ["gunicorn", "modernomad.wsgi"]
 
 # Copy all files last, because this is most likely to change
 COPY . /app/
 
-CMD ["./manage.py", "runserver", "0.0.0.0:8000"]
+RUN SECRET_KEY=unset ./manage.py collectstatic --noinput
+RUN SECRET_KEY=unset ./manage.py compress

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,13 @@ ENV MODE PRODUCTION
 # Number of gunicorn workers
 ENV WEB_CONCURRENCY 3
 EXPOSE 8000
-CMD ["gunicorn", "modernomad.wsgi"]
+
+# Make this configurable so we can build a worker image using just build args
+# (e.g. when using Compose or a CI system)
+ARG CUSTOM_CMD="gunicorn modernomad.wsgi"
+# ARG can't be used in CMD
+ENV CUSTOM_CMD=$CUSTOM_CMD
+CMD $CUSTOM_CMD
 
 # Copy all files last, because this is most likely to change
 COPY . /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,22 @@ COPY requirements.txt requirements.test.txt /app/
 WORKDIR /app
 RUN pip install --no-cache-dir -r requirements.txt -r requirements.test.txt
 
+# Same, but for client
+RUN mkdir -p /app/client
+COPY client/package.json /app/client/
+RUN cd client && npm install && npm cache clean --force
+
+# Build client before copying everything so changes in Django don't trigger a
+# re-build
+COPY client /app/client
+RUN cd client && node_modules/.bin/webpack --config webpack.prod.config.js
+
+# Set configuration last so we can change this without rebuilding the whole
+# image
 ENV DJANGO_SETTINGS_MODULE modernomad.settings_docker
 EXPOSE 8000
 
+# Copy all files last, because this is most likely to change
 COPY . /app/
 
 CMD ["./manage.py", "runserver", "0.0.0.0:8000"]

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,8 +1,0 @@
-FROM node:8-alpine
-RUN mkdir -p /app
-WORKDIR /app
-COPY package.json /app/
-RUN npm install && npm cache clean --force
-COPY . /app/
-EXPOSE 3000
-RUN ["node", "server.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,6 @@ services:
     ports:
       - "8000:8000"
     environment:
-      - "BROKER_URL=amqp://guest:guest@rabbitmq//"
-      - "DATABASE_URL=postgres://postgres@postgres/postgres"
       - "SECRET_KEY=insecure - only for development"
       - "STRIPE_SECRET_KEY"
       - "STRIPE_PUBLISHABLE_KEY"
@@ -30,8 +28,6 @@ services:
     build: .
     command: ./manage.py celeryd --verbosity=2 --beat --schedule=celery --events --loglevel=INFO
     environment:
-      - "BROKER_URL=amqp://guest:guest@rabbitmq//"
-      - "DATABASE_URL=postgres://postgres@postgres/postgres"
       - "SECRET_KEY=insecure - only for development"
       - "STRIPE_SECRET_KEY"
       - "STRIPE_PUBLISHABLE_KEY"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,9 +28,9 @@ services:
     volumes:
       - "./:/app"
       - "/app/client/node_modules"
-  celery:
+  worker:
     build: .
-    command: ./manage.py celeryd --verbosity=2 --beat --schedule=celery --events --loglevel=INFO
+    command: scripts/celeryd
     environment:
       - "SECRET_KEY=insecure - only for development"
       - "MODE=DEVELOPMENT"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,12 @@ version: "3.0"
 services:
   web:
     build: .
+    command: ./manage.py runserver 0.0.0.0:8000
     ports:
       - "8000:8000"
     environment:
       - "SECRET_KEY=insecure - only for development"
+      - "MODE=DEVELOPMENT"
       - "STRIPE_SECRET_KEY"
       - "STRIPE_PUBLISHABLE_KEY"
       - "DISCOURSE_BASE_URL"
@@ -31,6 +33,7 @@ services:
     command: ./manage.py celeryd --verbosity=2 --beat --schedule=celery --events --loglevel=INFO
     environment:
       - "SECRET_KEY=insecure - only for development"
+      - "MODE=DEVELOPMENT"
       - "STRIPE_SECRET_KEY"
       - "STRIPE_PUBLISHABLE_KEY"
       - "DISCOURSE_BASE_URL"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,13 +17,15 @@ services:
     volumes:
       - "./:/app"
   client:
-    build: client/
+    build: .
+    working_dir: /app/client/
+    command: node server.js
     ports:
       - "3000:3000"
     # Bind mount app directory, but leave node_modules intact
     volumes:
-      - "./client/:/app"
-      - "/app/node_modules"
+      - "./:/app"
+      - "/app/client/node_modules"
   celery:
     build: .
     command: ./manage.py celeryd --verbosity=2 --beat --schedule=celery --events --loglevel=INFO

--- a/modernomad/local_settings.travis.py
+++ b/modernomad/local_settings.travis.py
@@ -81,7 +81,7 @@ BASE_DIR = os.path.normpath(ROOT + '/..')
 
 WEBPACK_LOADER = {
     'DEFAULT': {
-        'BUNDLE_DIR_NAME': 'client/dist/',
+        'BUNDLE_DIR_NAME': '',
         'STATS_FILE': os.path.join(BASE_DIR, 'client/webpack-stats-prod.json'),
     }
 }

--- a/modernomad/settings.py
+++ b/modernomad/settings.py
@@ -63,7 +63,7 @@ MEDIA_URL = "/media/"
 # in apps' "static/" subdirectories and in STATICFILES_DIRS.
 # Example: "/home/media/media.lawrence.com/static/"
 STATIC_ROOT = path("../../static/")
-STATICFILES_DIRS = ('static', '')
+STATICFILES_DIRS = ('static', 'client/dist')
 STATIC_URL = '/static/'
 STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',

--- a/modernomad/settings_docker.py
+++ b/modernomad/settings_docker.py
@@ -30,6 +30,8 @@ DATABASES = {
     'default': env.db(),
 }
 
+ALLOWED_HOSTS = env.list('ALLOWED_HOSTS', default=[])
+
 BROKER_URL = env('BROKER_URL', default='amqp://')
 CELERY_RESULT_BACKEND = env('BROKER_URL', default='amqp://')
 
@@ -42,7 +44,18 @@ STRIPE_PUBLISHABLE_KEY = env('STRIPE_PUBLISHABLE_KEY', default='')
 DISCOURSE_BASE_URL = env('DISCOURSE_BASE_URL', default='')
 DISCOURSE_SSO_SECRET = env('DISCOURSE_SSO_SECRET', default='')
 
+ADMINS = ((
+    env('ADMIN_NAME', default='Unnamed'),
+    env('ADMIN_EMAIL', default='none@example.com')
+),)
+
 MAILGUN_API_KEY = env('MAILGUN_API_KEY', default='')
+LIST_DOMAIN = env('LIST_DOMAIN', default='somedomain.com')
+EMAIL_SUBJECT_PREFIX = env('EMAIL_SUBJECT_PREFIX', default='[Modernomad] ')
+DEFAULT_FROM_EMAIL = env('DEFAULT_FROM_EMAIL', default='stay@example.com')
+
+GOOGLE_ANALYTICS_PROPERTY_ID = env('GOOGLE_ANALYTICS_PROPERTY_ID', default='')
+GOOGLE_ANALYTICS_DOMAIN = env('GOOGLE_ANALYTICS_DOMAIN', default='example.com')
 
 LOGGING = {
     'version': 1,

--- a/modernomad/settings_docker.py
+++ b/modernomad/settings_docker.py
@@ -1,8 +1,9 @@
-# A sensible set of defaults for a development environment, that can be
+# A sensible set of defaults for a production environment which can be
 # overridden with environment variables
 
 import environ
 from django.core.exceptions import ImproperlyConfigured
+import os
 from .settings import *
 
 env = environ.Env()
@@ -12,7 +13,7 @@ DEVELOPMENT = 0
 PRODUCTION = 1
 
 # default mode is production. change to dev as appropriate.
-env_mode = env('MODE', default='DEVELOPMENT')
+env_mode = env('MODE', default='PRODUCTION')
 if env_mode == 'DEVELOPMENT':
     MODE = DEVELOPMENT
     DEBUG = True
@@ -20,6 +21,19 @@ if env_mode == 'DEVELOPMENT':
 elif env_mode == 'PRODUCTION':
     MODE = PRODUCTION
     DEBUG = False
+
+    STATIC_ROOT = path("static_root/")
+
+    # Collect static gathers client/dist/ into root of static/,
+    # which is why bundle dir is blank
+    WEBPACK_LOADER = {
+        'DEFAULT': {
+            'BUNDLE_DIR_NAME': '',
+            'CACHE': True,
+            'STATS_FILE': os.path.join(BASE_DIR, 'client/webpack-stats-prod.json'),
+        }
+    }
+    COMPRESS_OFFLINE = True
 else:
     raise ImproperlyConfigured('Unknown MODE setting')
 
@@ -32,7 +46,7 @@ DATABASES = {
 
 ALLOWED_HOSTS = env.list('ALLOWED_HOSTS', default=[])
 
-BROKER_URL = env('BROKER_URL', default='amqp://guest:guest@rabbitmq//')
+BROKER_URL = env('BROKER_URL', default=env('CLOUDAMQP_URL', default='amqp://guest:guest@rabbitmq//'))
 CELERY_RESULT_BACKEND = BROKER_URL
 
 # this should be a TEST or PRODUCTION key depending on whether this is a local

--- a/modernomad/settings_docker.py
+++ b/modernomad/settings_docker.py
@@ -27,13 +27,13 @@ TEMPLATE_DEBUG = DEBUG
 
 SECRET_KEY = env('SECRET_KEY')
 DATABASES = {
-    'default': env.db(),
+    'default': env.db('DATABASE_URL', default='postgres://postgres@postgres/postgres'),
 }
 
 ALLOWED_HOSTS = env.list('ALLOWED_HOSTS', default=[])
 
-BROKER_URL = env('BROKER_URL', default='amqp://')
-CELERY_RESULT_BACKEND = env('BROKER_URL', default='amqp://')
+BROKER_URL = env('BROKER_URL', default='amqp://guest:guest@rabbitmq//')
+CELERY_RESULT_BACKEND = BROKER_URL
 
 # this should be a TEST or PRODUCTION key depending on whether this is a local
 # test/dev site or production!

--- a/modernomad/settings_docker.py
+++ b/modernomad/settings_docker.py
@@ -19,6 +19,7 @@ if env_mode == 'DEVELOPMENT':
     EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 elif env_mode == 'PRODUCTION':
     MODE = PRODUCTION
+    DEBUG = False
 else:
     raise ImproperlyConfigured('Unknown MODE setting')
 

--- a/modernomad/wsgi.py
+++ b/modernomad/wsgi.py
@@ -21,8 +21,11 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "modernomad.settings")
 # file. This includes Django's development server, if the WSGI_APPLICATION
 # setting points here.
 from django.core.wsgi import get_wsgi_application
+from whitenoise.django import DjangoWhiteNoise
+
 application = get_wsgi_application()
 
 # Apply WSGI middleware here.
 # from helloworld.wsgi import HelloWorldApplication
 # application = HelloWorldApplication(application)
+application = DjangoWhiteNoise(application)

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,8 @@ django-ical
 django-extensions
 Werkzeug
 django-environ==0.4.3
+gunicorn==19.7.1
+whitenoise==3.3.1
 
 # the stripe library requires custom arguments which the requirements.txt file
 # parsing apparently doesn't support, so install it manually on the command

--- a/scripts/celeryd
+++ b/scripts/celeryd
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec ./manage.py celeryd --verbosity=2 --beat --schedule=celery --events --loglevel=INFO


### PR DESCRIPTION
I have made the plain Dockerfile now work as a production version of the site, with all webpack and static stuff built correctly inside of it. The commits are well documented if you want to see reasoning behind the changes.

The particular use case is running this on Heroku, and I will follow-up this pull request will full instructions for getting a copy running on there. In theory it can be whittled down to [one click](https://devcenter.heroku.com/articles/heroku-button).

This only touches the Docker configuration, apart from a fix to the static files settings, and adding Whitenoise to the WSGI app (which makes serving static files more efficient). 

(Based on top of #297.)