### PR TITLE
Fix failing Heroku build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,10 @@ RUN apk add --no-cache \
   zlib \
   zlib-dev
 
+# https://bitbucket.org/site/master/issues/16334/pipelines-failing-with-could-not-get-uid
+# https://github.com/npm/npm/issues/20861
+RUN npm config set unsafe-perm true
+
 RUN npm install -g less
 
 # Only copy requirements so cache isn't busted by changes in the app


### PR DESCRIPTION
Seems like there is some incompatibility with npm and Amazon's new
EC2 instances. Good grief.

https://github.com/npm/npm/issues/20861