### PR TITLE
Add Sentry for logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
 install:
   - "pip install -U pip wheel"
   - "nvm install 8"
-  - "pip install -r requirements.txt -r requirements.test.txt"
+  - "pip install -r requirements.txt"
 before_script:
   - psql -c 'create database test_db;' -U postgres
   - "cd client && npm install && cd .."

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,9 @@ RUN npm install -g less
 
 # Only copy requirements so cache isn't busted by changes in the app
 RUN mkdir -p /app
-COPY requirements.txt requirements.test.txt /app/
+COPY requirements.txt /app/
 WORKDIR /app
-RUN pip install --no-cache-dir -r requirements.txt -r requirements.test.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 # Same, but for client
 RUN mkdir -p /app/client

--- a/modernomad/settings/common.py
+++ b/modernomad/settings/common.py
@@ -69,12 +69,10 @@ if AWS_STORAGE_BUCKET_NAME:
 
 SENTRY_DSN = env('SENTRY_DSN', default='')
 if SENTRY_DSN:
-    print("Found Sentry DSN")
     sentry_sdk.init(
         dsn=SENTRY_DSN,
         integrations=[DjangoIntegration(), sentry_logging]
     )
-
 
 # Absolute path to the directory static files should be collected to.
 # Don't put anything in this directory yourself; store your static files

--- a/modernomad/settings/common.py
+++ b/modernomad/settings/common.py
@@ -4,6 +4,8 @@ import datetime
 import sys
 from pathlib import Path
 import environ
+import sentry_sdk
+from sentry_sdk.integrations.django import DjangoIntegration
 
 env = environ.Env()
 
@@ -64,6 +66,15 @@ AWS_DEFAULT_ACL = 'public-read'
 if AWS_STORAGE_BUCKET_NAME:
     DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
     MEDIA_URL = env('MEDIA_URL', default='https://%s.s3.amazonaws.com/' % AWS_STORAGE_BUCKET_NAME)
+
+SENTRY_DSN = env('SENTRY_DSN', default='')
+if SENTRY_DSN:
+    print("Found Sentry DSN")
+    sentry_sdk.init(
+        dsn=SENTRY_DSN,
+        integrations=[DjangoIntegration(), sentry_logging]
+    )
+
 
 # Absolute path to the directory static files should be collected to.
 # Don't put anything in this directory yourself; store your static files
@@ -244,38 +255,6 @@ LOGGING = {
         },
         'simple': {
             'format': '%(levelname)s %(message)s'
-        },
-    },
-    'handlers': {
-        'file': {
-            'level': 'DEBUG',
-            'class': 'logging.FileHandler',
-            'filename': './django.log',
-            'formatter': 'simple',
-        }
-    },
-    'loggers': {
-        'django': {
-            'handlers': ['file'],
-            'level': 'INFO',
-            'propagate': True,
-        },
-        'django.request': {
-            'handlers': ['file'],
-            'level': 'INFO',
-            'propagate': True,
-        },
-        'core': {
-            'handlers': ['file'],
-            'level': 'DEBUG',
-        },
-        'modernomad': {
-            'handlers': ['file'],
-            'level': 'DEBUG',
-        },
-        'gather': {
-            'handlers': ['file'],
-            'level': 'DEBUG',
         },
     },
 }

--- a/modernomad/settings/production.py
+++ b/modernomad/settings/production.py
@@ -4,22 +4,6 @@ from .common import BASE_DIR
 
 SECRET_KEY = env('SECRET_KEY')
 
-LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'handlers': {
-        'console': {
-            'class': 'logging.StreamHandler',
-        },
-    },
-    'loggers': {
-        'django': {
-            'handlers': ['console'],
-            'level': env('DJANGO_LOG_LEVEL', default='INFO'),
-        },
-    },
-}
-
 WEBPACK_LOADER = {
     'DEFAULT': {
         'BUNDLE_DIR_NAME': '',

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,6 +1,0 @@
-behave
-django-behave
-factory_boy
-splinter
-selenium
-robber

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,4 @@ whitenoise==3.3.1
 django-storages==1.6.5
 boto3==1.9.25
 sentry-sdk==0.6.8
+factory_boy

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,3 +38,4 @@ gunicorn==19.7.1
 whitenoise==3.3.1
 django-storages==1.6.5
 boto3==1.9.25
+sentry-sdk==0.6.8


### PR DESCRIPTION
Configure logging to use sentry.io. Requires `SENTRY_DSN` environment variable locally or on Heroku. 