### PR TITLE
Use postgres for local config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,14 @@ services:
   - postgresql
 env:
   - DJANGO_SETTINGS_MODULE=modernomad.settings.local
-    DATABASE_URL=postgres://postgres@localhost/test_db
+    DATABASE_URL=postgres://modernomad@localhost/modernomad
 install:
   - "pip install -U pip wheel"
   - "nvm install 8"
   - "pip install -r requirements.txt"
 before_script:
-  - psql -c 'create database test_db;' -U postgres
+  - psql -c 'create database modernomad;' -U postgres
+  - psql -c 'create user modernomad;' -U postgres
   - "cd client && npm install && cd .."
   - "cd client && ./node_modules/.bin/webpack --config webpack.prod.config.js && cd .."
 script: ./manage.py test

--- a/modernomad/settings/local.py
+++ b/modernomad/settings/local.py
@@ -8,3 +8,13 @@ INSTALLED_APPS = INSTALLED_APPS + [
 SECRET_KEY = 'local_development'
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'USER': 'modernomad',
+        'NAME': 'modernomad',
+        'PASSWORD': '',
+    }
+}
+


### PR DESCRIPTION
Small change to use Postgres as the local development database. I think this makes sense unless we explicitly decide to commit to [cross-DB sql support](https://evertpot.com/writing-sql-for-postgres-mysql-sqlite/) (which seems unlikely at the moment). This will let us develop and test in environments as similar as possible to production. 

We should also include updated install instructions for database setup in #322. 