### PR TITLE
Remove staging settings

### DIFF
--- a/modernomad/settings/staging.py
+++ b/modernomad/settings/staging.py
@@ -1,4 +1,0 @@
-from .common import *  # noqa
-from .common import env
-
-SECRET_KEY = env('SECRET_KEY')


### PR DESCRIPTION
These aren't actually used, so remove to avoid confusing.
Staging uses production settings.