### PR TITLE
Use Postgres 10 in dev environment

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -29,4 +29,4 @@ services:
     volumes:
       - "./media:/app/media"
   postgres:
-    image: postgres
+    image: postgres:10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,4 +27,4 @@ services:
       - "./:/app"
       - "/app/client/node_modules"
   postgres:
-    image: postgres
+    image: postgres:10


### PR DESCRIPTION
Just a little thing for consistency with production.
Default is 11, but we use 10 in production.

I discovered this when building the backup tool, and the v10 client couldn't backup my v11 development environment!