### PR TITLE
Pin graphene and graphql versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,8 +11,8 @@ django-webpack-loader==0.6.0
 Django==1.11.20
 djangorestframework==3.6.4
 graphene-django==2.2.0
-graphene<3,>=2.1.3
-graphql-core<3,>=2.1.0
+graphene==2.1.3
+graphql-core==2.1.0
 graphql-relay==0.4.5
 icalendar==4.0.3
 lxml==4.3.2


### PR DESCRIPTION
Much safer to pin to specific versions, and means dependabot can bump them.