### PR TITLE
Make bookings page not use a gazillion queries

### DIFF
--- a/modernomad/settings/local.py
+++ b/modernomad/settings/local.py
@@ -8,3 +8,11 @@ INSTALLED_APPS = INSTALLED_APPS + [
 SECRET_KEY = 'local_development'
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+
+MIDDLEWARE_CLASSES = MIDDLEWARE_CLASSES + (
+    'debug_toolbar.middleware.DebugToolbarMiddleware',
+)
+DEBUG_TOOLBAR_CONFIG = {
+    'SHOW_TOOLBAR_CALLBACK': lambda request: True if DEBUG else False,
+    'RESULTS_CACHE_SIZE': 100,
+}

--- a/modernomad/urls/main.py
+++ b/modernomad/urls/main.py
@@ -47,3 +47,14 @@ media_url = settings.MEDIA_URL.lstrip('/').rstrip('/')
 urlpatterns += [
     url(r'^%s/(?P<path>.*)$' % media_url, django.views.static.serve, {'document_root': settings.MEDIA_ROOT, 'show_indexes': True}),
 ]
+
+if settings.DEBUG:
+    import debug_toolbar
+    urlpatterns = [
+        # For Django >= 2.0
+        # path('__debug__/', include(debug_toolbar.urls)),
+
+        # For django versions before 2.0:
+        url(r'^__debug__/', include(debug_toolbar.urls)),
+
+    ] + urlpatterns


### PR DESCRIPTION
Before:
<img width="238" alt="screenshot 2019-03-05 17 52 39" src="https://user-images.githubusercontent.com/40906/53851798-b069f100-3f74-11e9-89a0-02fa06f069a7.png">

After:
<img width="225" alt="screenshot 2019-03-05 17 47 40" src="https://user-images.githubusercontent.com/40906/53851815-c081d080-3f74-11e9-8f33-de1c3dc560b5.png">

It doesn't load at all on Heroku because it has a 30s timeout.