### PR TITLE
Suppress stay page when there are no active rooms

### DIFF
--- a/core/templates/location_detail.html
+++ b/core/templates/location_detail.html
@@ -15,6 +15,7 @@
             {{ location.short_description|safe }}
         </div>
 
+        {% if location.rooms_with_future_capacity %}
         <div class="col-sm-5 text-center book-room">
             <h3>BOOK A ROOM</h3>
             <div class="booking-dates top-spacer">
@@ -33,6 +34,7 @@
             <h4>-OR-</h4>
             <h3><a href="stay" class="btn btn-lg btn-primary btn-brand">View all rooms</a></h3>
         </div>
+        {% endif %}
     </div>
 
     <div class="row">

--- a/core/views/booking.py
+++ b/core/views/booking.py
@@ -32,6 +32,10 @@ def StayComponent(request, location_slug, room_id=None):
         user_drft_balance = 0
 
     location = get_object_or_404(Location, slug=location_slug)
+    if not location.rooms_with_future_capacity():
+        messages.add_message(request, messages.INFO, 'Sorry! This location does not currently have any listings.')
+        return HttpResponseRedirect(reverse("location_detail", args=(location.slug, )))
+
     if request.user in location.house_admins.all():
         is_house_admin = "true"
     else:


### PR DESCRIPTION
When there are no "active rooms" (no future capacities on location.rooms):

* stay page link is suppressed in menu (was pre-existing)
* suppress "book a room" block on location landing page   
* redirect away from /stay page if loaded directly with a message to user. 

Closes #361 