### PR TITLE
Fix page reflows in various places

### DIFF
--- a/modernomad/core/templates/location_list.html
+++ b/modernomad/core/templates/location_list.html
@@ -12,7 +12,7 @@
 
         <a href="{% url 'location_detail' location.slug %}" class="col-lg-4 col-md-6">
             <div class="location-box">
-                <img src="{{MEDIA_URL}}{{location.profile_image}}" class="location-photo panel panel-default">
+                <img src="{{MEDIA_URL}}{{location.profile_image}}" class="location-photo panel panel-default" width="336" height="344">
                 <div class="location-name">
               <h2 class="bold">{{ location.name }}<br> <em class="small">{{ location.address}}</em></h2>
             </div>

--- a/static/css/custom.less
+++ b/static/css/custom.less
@@ -190,6 +190,12 @@ a:hover {
 
 .house-box {
   position: relative;
+  // HACK: Size this correctly before .house-image has loaded so there
+  // isn't a reflow once it has loaded.
+  // https://www.voorhoede.nl/en/blog/say-no-to-image-reflow/
+  height: 0;
+  padding-bottom: 100% / (800 / 225); // house-image is 800x225px
+  overflow: hidden;
 }
 
 .house-image {

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,7 +5,7 @@
 
 <div class="jumbotron home-page" id="center">
     <div class="container text-center dept-of-housing">
-        <img src="{% static 'img/en-logo-transparent.png' %}" class="logo" alt="" />
+        <img src="{% static 'img/en-logo-transparent.png' %}" class="logo" alt="" width="87" height="70">
         <h2>
             <span class="bold">Embassy Network</span> 
         </h2>
@@ -24,7 +24,7 @@
 
         <a href="{% url 'location_detail' location.slug %}" class="col-lg-4 col-md-6">
             <div class="location-box">
-                <img src="{{MEDIA_URL}}{{location.profile_image}}" class="location-photo panel panel-default">
+                <img src="{{MEDIA_URL}}{{location.profile_image}}" class="location-photo panel panel-default" width="336" height="344">
                 <div class="location-name">
               <h2 class="bold">{{ location.name }}<br> <em class="small">{{ location.address}}</em></h2>
             </div>

--- a/templates/root.html
+++ b/templates/root.html
@@ -41,7 +41,7 @@
                             <span class="icon-bar"></span>
                             <span class="icon-bar"></span>
                         </button>
-                        <a href="/" class="navbar-brand"><span class="highlight"><img src="{% static 'img/en-logo-transparent.png' %}" class="logo" alt="" /> Embassy Network</span></a>
+                        <a href="/" class="navbar-brand"><span class="highlight"><img src="{% static 'img/en-logo-transparent.png' %}" class="logo" alt="" width="37" height="30"> Embassy Network</span></a>
                     </div>
                     <div class="collapse navbar-collapse" id="main-navbar">
                         <ul class="nav navbar-nav navbar-left">


### PR DESCRIPTION
Just a little thing that was irritating me. Also a minor performance issue.

The main one was on location pages. Before the main image had loaded the page is a mess:

![Screenshot 2019-04-05 16 30 13](https://user-images.githubusercontent.com/40906/55639105-8e0c0300-57c0-11e9-91f8-809ce7cb5ac7.png)

I have now fixed it so it isn't a mess:

![Screenshot 2019-04-05 16 30 44](https://user-images.githubusercontent.com/40906/55639160-a2500000-57c0-11e9-8131-50a7917d79dc.png)

This also avoids the page being reflowed a second time, which caused a flash of a different page layout before the image had loaded. (Or, a long flash if you are on a slow network connection...)

Fixes #469