### PR TITLE
Fix custom email templates

### DIFF
--- a/modernomad/core/emails/messages.py
+++ b/modernomad/core/emails/messages.py
@@ -127,6 +127,7 @@ def send_subscription_receipt(subscription, bill):
 def send_invoice(booking):
     ''' trigger a reminder email to the guest about payment.'''
     if booking.is_comped():
+        # FIXME: undefined!
         return send_comp_invoice(booking)
 
     location = booking.use.location

--- a/modernomad/core/tasks.py
+++ b/modernomad/core/tasks.py
@@ -34,16 +34,27 @@ def send_guest_welcome():
     logger.info("Running task: send_guest_welcome")
     # get all bookings WELCOME_EMAIL_DAYS_AHEAD from now.
     locations = Location.objects.all()
+
+    # to ensure tests actually do something
+    did_send_email = False
+
     for location in locations:
         soon = datetime.datetime.today() + datetime.timedelta(days=location.welcome_email_days_ahead)
         upcoming = Use.objects.filter(location=location).filter(arrive=soon).filter(status='confirmed')
         for booking in upcoming:
             guest_welcome(booking)
+            did_send_email = True
+
+    return did_send_email
 
 
 @catch_exceptions
 def send_departure_email():
     logger.info("Running task: send_departure_email")
+
+    # to ensure tests actually do something
+    did_send_email = False
+
     # get all bookings departing today
     locations = Location.objects.all()
     for location in locations:
@@ -51,6 +62,9 @@ def send_departure_email():
         departing = Use.objects.filter(location=location).filter(depart=today).filter(status='confirmed')
         for use in departing:
             goodbye_email(use)
+            did_send_email = True
+    
+    return did_send_email
 
 
 @catch_exceptions

--- a/modernomad/core/tests/test_emails.py
+++ b/modernomad/core/tests/test_emails.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 import unittest
 from modernomad.core.factories import ResourceFactory
 from django.contrib.auth.models import User
-from modernomad.core.models import Payment, Use, Booking, UserProfile
+from modernomad.core.models import Payment, Use, Booking, UserProfile, LocationEmailTemplate
 from modernomad.core.emails.messages import new_booking_notify, send_booking_receipt, updated_booking_notify, admin_daily_update
 from modernomad.core.tasks import send_departure_email, send_guest_welcome, guests_residents_daily_update
 from django.utils import timezone
@@ -88,6 +88,15 @@ class EmailsTestCase(TestCase):
     def test_guest_welcome(self):
         # test the task, which calls guest_welcome() in emails.py
         self.assertTrue(send_guest_welcome())
+
+    def test_guest_welcome_with_location_email_override(self):
+        LocationEmailTemplate.objects.create(
+            location=self.resource.location,
+            key=LocationEmailTemplate.WELCOME,
+            text_body="hi {{first_name}}",
+            html_body="hi {{first_name}}")
+        self.assertTrue(send_guest_welcome())
+
 
     def test_guests_residents_daily_update(self):
         # called here directly instead as the task, because we can get the

--- a/modernomad/core/tests/test_emails.py
+++ b/modernomad/core/tests/test_emails.py
@@ -82,12 +82,12 @@ class EmailsTestCase(TestCase):
     # automated emails (called from tasks.py)
     def test_departure_email(self):
         # test the task, which calls goodbye_email() in emails.py
-        send_departure_email()
+        self.assertTrue(send_departure_email())
 
 
     def test_guest_welcome(self):
-        # test the task, which calls goodbye_email() in emails.py
-        send_guest_welcome()
+        # test the task, which calls guest_welcome() in emails.py
+        self.assertTrue(send_guest_welcome())
 
     def test_guests_residents_daily_update(self):
         # called here directly instead as the task, because we can get the


### PR DESCRIPTION
As seen in Sentry, welcome emails were failing to send because custom email templates was broken. This was a bit gnarly - it wasn't presenting locally because it was a bug with custom email templates, not the built-ins. Details are in commit messages.

Fixes #493