### PR TITLE
Attempt to fix flakey email tests

### DIFF
--- a/modernomad/core/tests/test_emails.py
+++ b/modernomad/core/tests/test_emails.py
@@ -44,7 +44,7 @@ class EmailsTestCase(TestCase):
         self.admin = self.create_user('admin1', admin=True, email='admin1@bob.com')
         self.booking = self.create_booking(user=self.guest1)
 
-        today = datetime.now().date()
+        today = timezone.localtime(timezone.now())
         yesterday = today + timedelta(days=-1)
         in_two_days = today + timedelta(days=2)
         after_that = in_two_days + timedelta(days=1)


### PR DESCRIPTION
Sometimes these tests don't send out emails, e.g. in #540.

This is a guess at a fix -- the test and the real implementation
use a different definition of "today" so I'm guessing it fails
intermittently when the timezone and UTC version of today differs.

These opens up a can of timezone worms -- various tasks use
different definitions of today, most importantly the billing one.

I haven't thought about this in much detail but I think this will
fix the test at least. 😬