### PR TITLE
Fix Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.8-slim
+FROM python:3.6
 
 RUN apt-get update -qq && apt-get install -yq \
     build-essential \

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ django-debug-toolbar==1.11
 django-environ==0.4.5
 django-extensions==2.2.1
 django-filter==2.2.0
-django-flatpages-tinymce==0.1.1
 django-ical==1.5
 django-imagekit==4.0.2
 django-jwt-auth==0.0.2


### PR DESCRIPTION
This PR adjusts Docker base image from `python:3.6.8-slim` to `python:3.6` because debian no longer provide apt repositories for debian stretch slim version:

```
1.034 W: The repository 'http://security.debian.org/debian-security stretch/updates Release' does not have a Release file.
1.034 W: The repository 'http://deb.debian.org/debian stretch Release' does not have a Release file.
1.034 W: The repository 'http://deb.debian.org/debian stretch-updates Release' does not have a Release file.
1.034 E: Failed to fetch http://security.debian.org/debian-security/dists/stretch/updates/main/binary-arm64/Packages  404  Not Found
1.034 E: Failed to fetch http://deb.debian.org/debian/dists/stretch/main/binary-arm64/Packages  404  Not Found
1.034 E: Failed to fetch http://deb.debian.org/debian/dists/stretch-updates/main/binary-arm64/Packages  404  Not Found
```

Also, `django-flatpages-tinymce` is removed as it's no longer compatible with other requirements:

```
1.432 ERROR: Could not find a version that satisfies the requirement django-flatpages-tinymce==0.1.1 (from versions: none)
1.432 ERROR: No matching distribution found for django-flatpages-tinymce==0.1.1
```

I don't know where `django-flatpages-tinymce` is used (it will no longer work) but this can be solved if we have a working dev build.